### PR TITLE
Hanami plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+vendor/

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--color
 --require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ unless ENV["TRAVIS"]
   gem "yard",   require: false
 end
 
+gem "hanami",          git: "https://github.com/hanami/hanami.git",   require: false, branch: "develop"
 gem "hanami-devtools", git: "https://github.com/hanami/devtools.git", require: false

--- a/hanami-webconsole.gemspec
+++ b/hanami-webconsole.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "better_errors", "~> 2.4"
+  spec.add_dependency "binding_of_caller", "~> 0.8"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.7"

--- a/lib/hanami/webconsole.rb
+++ b/lib/hanami/webconsole.rb
@@ -2,7 +2,10 @@
 
 module Hanami
   # Hanami web console for development
+  #
+  # @since 0.1.0
   module Webconsole
     require "hanami/webconsole/version"
+    require "hanami/webconsole/plugin"
   end
 end

--- a/lib/hanami/webconsole/plugin.rb
+++ b/lib/hanami/webconsole/plugin.rb
@@ -5,5 +5,5 @@ require "binding_of_caller"
 
 Hanami.plugin do
   middleware.use BetterErrors::Middleware
-  BetterErrors.application_root = Hanami.root
+  BetterErrors.application_root = Hanami.root.to_s
 end

--- a/lib/hanami/webconsole/plugin.rb
+++ b/lib/hanami/webconsole/plugin.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "better_errors"
+require "binding_of_caller"
+
+Hanami.plugin do
+  middleware.use BetterErrors::Middleware
+  BetterErrors.application_root = Hanami.root
+end

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+run_code_quality_checks() {
+  bundle exec rubocop .
+}
+
+run_unit_tests() {
+  bundle exec rake spec:coverage
+}
+
+run_integration_tests() {
+  local pwd=$PWD
+  local root="$pwd/spec/integration"
+
+  for test in $(find $root -name '*_spec.rb')
+  do
+    run_integration_test $test
+
+    if [ $? -ne 0 ]; then
+      local exit_code=$?
+      echo "Failing test: $test"
+      exit $exit_code
+    fi
+  done
+}
+
+run_integration_test() {
+  local test=$1
+
+  printf "\n\n\nRunning: $test\n"
+  bundle exec rspec $test
+}
+
+run_test() {
+  local test=$1
+
+  printf "\n\n\nRunning: $test\n"
+  COVERAGE=true bundle exec rspec $test
+}
+
+main() {
+  run_code_quality_checks &&
+    run_unit_tests &&
+    run_integration_tests
+}
+
+main

--- a/spec/integration/show_error_page_spec.rb
+++ b/spec/integration/show_error_page_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe "Show error page", type: :integration do
+  it "shows error page on exception" do
+    with_project do
+      generate "action web home#index --url=/"
+      rewrite "apps/web/controllers/home/index.rb", <<~CODE
+        module Web::Controllers::Home
+          class Index
+            include Web::Action
+
+            def call(params)
+              params.foo
+            end
+          end
+        end
+CODE
+
+      server("no-code-reloading" => nil) do
+        get "/"
+
+        expect(last_response.status).to eq(500)
+        expect(last_response.body).to   include("NoMethodError")
+        expect(last_response.body).to   include("params.foo")
+      end
+    end
+  end
+
+  private
+
+  def with_project
+    super("bookshelf", gems: { "hanami-webconsole" => { groups: [:development], path: Pathname.new(__dir__).join("..", "..", "..").realpath.to_s } }) do
+      yield
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,3 +23,5 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+require "hanami/devtools/integration"


### PR DESCRIPTION
Use `better_errors` and `binding_of_caller` gems and package them as an Hanami plugin.

From my Hanami project (`bookshelf`) the only thing that I need to do is:

```ruby
# Gemfile
group :development do
  gem "hanami-webconsole"
end
```