### PR TITLE
Add binding-of-caller just for mri platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem "hanami",             "~> 1.2", require: false, git: "https://github.com/han
 
 gem "hanami-devtools", git: "https://github.com/hanami/devtools.git", require: false
 
+platforms :mri do
+  gem "binding_of_caller", "~> 0.8"
+end
+
 platforms :ruby do
   gem 'sqlite3'
 end

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Status
 
-[![Gem Version](http://img.shields.io/gem/v/hanami-webconsole.svg)](https://badge.fury.io/rb/hanami-webconsole)
-[![Build Status](http://img.shields.io/travis/hanami/webconsole/master.svg)](https://travis-ci.org/hanami/webconsole?branch=master)
+[![Gem Version](https://badge.fury.io/rb/hanami-webconsole.svg)](https://badge.fury.io/rb/hanami-webconsole)
+[![Build Status](https://secure.travis-ci.org/hanami/webconsole.svg?branch=master)](https://travis-ci.org/hanami/webconsole?branch=master)
 
 ## Installation
 

--- a/hanami-webconsole.gemspec
+++ b/hanami-webconsole.gemspec
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)
@@ -24,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "better_errors", "~> 2.4"
-  spec.add_dependency "binding_of_caller", "~> 0.8"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
This PR implements #2 

Since there isn't an alternative for Jruby of `binding-of-caller` gem, at least we need to add this dependency only for mri interpreter.

Fix badges in readme

cc @nerdinand