### PR TITLE
Add Ruby 3.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"


### PR DESCRIPTION
I'm not sure how we could test this, since it's essetially just a better-errors extension, but right now the only test in this codebase is checking for VERSION