### PR TITLE
Update binding_of_caller

### DIFF
--- a/hanami-webconsole.gemspec
+++ b/hanami-webconsole.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2"
 
   spec.add_runtime_dependency "better_errors", "~> 2.10", ">= 2.10.1"
-  spec.add_runtime_dependency "binding_of_caller", "~> 1.0"
+  spec.add_runtime_dependency "binding_of_caller", "~> 2.0"
 end
 

--- a/lib/hanami/webconsole.rb
+++ b/lib/hanami/webconsole.rb
@@ -1,21 +1,5 @@
 # frozen_string_literal: true
 
-if RUBY_ENGINE == "ruby"
-  # Skip binding_of_caller's version check and force it to load on Ruby 4.0.
-  #
-  # Remove this shim once https://github.com/banister/binding_of_caller/pull/90 is merged and a new
-  # release has been made.
-  require "binding_of_caller/version"
-  require "binding_of_caller/mri"
-
-  # Prevent a direct require to "binding_of_caller", which is no longer needed by this point, and
-  # which prints a misleading warning about it not supporting Ruby 4.0, which we've fixed ourselves
-  # via the above.
-  $LOADED_FEATURES << "binding_of_caller.rb"
-else
-  require "binding_of_caller"
-end
-
 require "better_errors"
 
 module Hanami

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -10,4 +10,4 @@ gemspec:
   homepage: "https://hanamirb.org"
   runtime_dependencies:
     - ["better_errors", "~> 2.10", ">= 2.10.1"]
-    - ["binding_of_caller", "~> 1.0"]
+    - ["binding_of_caller", "~> 2.0"]


### PR DESCRIPTION
There was a new release of `binding_of_calller`, I was subscribed to the thread and noted your comment:

https://github.com/banister/binding_of_caller/pull/90#issuecomment-3650713216

Couldn't write a test for this, nor provide a `bundler/inline` file. However, I've tested it manually by spinning up a new `hanami`, pointing the `Gemfile` to my branch and raising an error within a controller.